### PR TITLE
feat(auth): support OAuth 2.0 client_credentials grant

### DIFF
--- a/servicenow_api/api/api_client_base.py
+++ b/servicenow_api/api/api_client_base.py
@@ -385,6 +385,37 @@ class ServiceNowApiBase:
                 "Authorization": f"Bearer {self.token}",
                 "Content-Type": "application/json",
             }
+        elif client_id and client_secret and grant_type == "client_credentials":
+            # OAuth 2.0 client credentials grant: the client authenticates as
+            # itself, so no username/password is required. Useful for
+            # integration accounts backed by an OAuth application registration.
+            self.auth_headers = {"Content-Type": "application/x-www-form-urlencoded"}
+            self.auth_data = {
+                "grant_type": "client_credentials",
+                "client_id": client_id,
+                "client_secret": client_secret,
+            }
+            encoded_data_str = urlencode(self.auth_data)
+            response = None
+            try:
+                response = self._session.post(
+                    url=self.auth_url,
+                    data=encoded_data_str,
+                    headers=self.auth_headers,
+                    timeout=30,
+                )
+                response = response.json()
+                self.token = response["access_token"]
+            except Exception as e:
+                print(
+                    f"Error Authenticating with OAuth: \n\n{type(e).__name__}\n\nResponse: {response}",
+                    file=sys.stderr,
+                )
+                raise e
+            self.headers = {
+                "Authorization": f"Bearer {self.token}",
+                "Content-Type": "application/json",
+            }
         elif username and password and client_id and client_secret:
             self.auth_headers = {"Content-Type": "application/x-www-form-urlencoded"}
             self.auth_data = {

--- a/servicenow_api/auth.py
+++ b/servicenow_api/auth.py
@@ -4,7 +4,11 @@ Authentication priority:
 1. **OIDC Delegation** — If ``ENABLE_DELEGATION`` is active, exchanges
    the IdP-issued user token for a downstream ServiceNow access token
    via RFC 8693 Token Exchange using the shared ``delegated_auth`` helper.
-2. **Basic Auth** — Falls back to ``SERVICENOW_USERNAME`` /
+2. **OAuth client credentials** — If ``SERVICENOW_GRANT_TYPE`` is
+   ``client_credentials`` and ``SERVICENOW_CLIENT_ID`` /
+   ``SERVICENOW_CLIENT_SECRET`` are set, authenticates as the OAuth
+   application itself (no username/password).
+3. **Basic Auth** — Falls back to ``SERVICENOW_USERNAME`` /
    ``SERVICENOW_PASSWORD`` with optional OAuth client credentials.
 
 See ``docs/guides/oauth_sso.md`` in agent-utilities for full details.
@@ -79,7 +83,22 @@ def get_client(
             logger.error("OIDC delegation failed", extra={"error": "Operation failed"})
             raise
 
-    # --- Path 2: Basic Auth (username/password + optional OAuth client) ---
+    # --- Path 2: OAuth 2.0 client credentials grant ---
+    # Set SERVICENOW_GRANT_TYPE=client_credentials to authenticate as an OAuth
+    # application (client_id/client_secret) with no username/password — e.g. an
+    # integration account backed by an OAuth application registration.
+    grant_type = setting("SERVICENOW_GRANT_TYPE", "password")
+    if grant_type == "client_credentials" and client_id and client_secret:
+        logger.info("Using OAuth client_credentials credentials for ServiceNow API")
+        return Api(
+            url=instance,
+            client_id=client_id,
+            client_secret=client_secret,
+            grant_type="client_credentials",
+            tls_profile=profile,
+        )
+
+    # --- Path 3: Basic Auth (username/password + optional OAuth client) ---
     try:
         if username or password:
             logger.info("Using username/password credentials for ServiceNow API")
@@ -100,5 +119,7 @@ def get_client(
         ) from e
 
     raise ValueError(
-        "No auth method: Provide token, enable delegation, or set SERVICENOW_USERNAME/PASSWORD"
+        "No auth method: Provide token, enable delegation, set "
+        "SERVICENOW_GRANT_TYPE=client_credentials with client_id/secret, or set "
+        "SERVICENOW_USERNAME/PASSWORD"
     )

--- a/tests/test_auth_coverage.py
+++ b/tests/test_auth_coverage.py
@@ -85,6 +85,34 @@ def test_auth_basic_auth_success():
                 assert kwargs["url"] == "https://dev12345.service-now.com"
 
 
+def test_auth_client_credentials_success():
+    with patch.dict(
+        os.environ,
+        {
+            "SERVICENOW_INSTANCE": "https://dev12345.service-now.com",
+            "SERVICENOW_GRANT_TYPE": "client_credentials",
+        },
+    ):
+        with patch(
+            "agent_utilities.mcp.delegated_auth.is_delegation_enabled",
+            return_value=False,
+        ):
+            with patch("servicenow_api.auth.Api") as mock_api_cls:
+                client = get_client(
+                    client_id="my-client-id", client_secret="my-client-secret"
+                )
+                assert client is not None
+                assert mock_api_cls.called
+                _, kwargs = mock_api_cls.call_args
+                assert kwargs["client_id"] == "my-client-id"
+                assert kwargs["client_secret"] == "my-client-secret"
+                assert kwargs["grant_type"] == "client_credentials"
+                assert kwargs["url"] == "https://dev12345.service-now.com"
+                # client_credentials must not require or pass a user login
+                assert "username" not in kwargs or kwargs["username"] is None
+                assert "password" not in kwargs or kwargs["password"] is None
+
+
 def test_auth_basic_auth_failure_autherror():
     with patch.dict(
         os.environ, {"SERVICENOW_INSTANCE": "https://dev12345.service-now.com"}


### PR DESCRIPTION
## What

Adds an OAuth 2.0 **client_credentials** authentication path so an integration account backed by an OAuth application registration can authenticate with only a `client_id` / `client_secret` — no username/password and no OIDC delegation.

## Why

ServiceNow OAuth application registrations commonly issue tokens via the `client_credentials` grant for machine-to-machine integrations (no interactive user). Today `get_client()` only supports OIDC delegation, the password grant, or HTTP Basic — all of which require a user identity. A pure `client_id`/`client_secret` integration therefore falls through to `ValueError("No auth method…")`. This is a common deployment shape (e.g. running the MCP server against an instance where only a client-credentials OAuth app is provisioned).

## Changes

- **`servicenow_api/auth.py` → `get_client()`**: when `SERVICENOW_GRANT_TYPE=client_credentials` and `client_id`/`client_secret` are set, build an `Api()` with `grant_type="client_credentials"`.
- **`servicenow_api/api/api_client_base.py` → `ServiceNowApiBase.__init__`**: new `client_credentials` branch that POSTs `grant_type=client_credentials` (client_id/secret only) to `/oauth_token.do` and uses the returned bearer token.
- Module docstring updated; unit test added in `tests/test_auth_coverage.py` covering the new path.

## Backwards compatibility

No behaviour change unless `SERVICENOW_GRANT_TYPE=client_credentials` is set:
- Default remains the password grant / HTTP Basic (`SERVICENOW_USERNAME`/`PASSWORD`).
- OIDC delegation (`ENABLE_DELEGATION`) still takes precedence when enabled.

## Testing

- `python -m py_compile` on both changed modules.
- Added `test_auth_client_credentials_success` mirroring the existing auth-coverage tests (asserts `Api()` is called with `grant_type="client_credentials"` and no username/password). Note: I couldn't run the full pytest suite locally (offline; `agent_utilities` not installable in my env) — CI will exercise it.

Signed-off-by: David J. M. Karlsen <david@davidkarlsen.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)